### PR TITLE
Switch OpenAI backend to DeepSeek

### DIFF
--- a/aide/backend/__init__.py
+++ b/aide/backend/__init__.py
@@ -7,7 +7,7 @@ logger = logging.getLogger("aide")
 
 
 def determine_provider(model: str) -> str:
-    if re.match(r"^(gpt-|o\d-|codex-mini-latest$)", model):
+    if re.match(r"^(gpt-|o\d-|codex-mini-latest$)", model) or model.startswith("deepseek-"):
         return "openai"
     elif model.startswith("claude-"):
         return "anthropic"

--- a/aide/backend/backend_openai.py
+++ b/aide/backend/backend_openai.py
@@ -9,6 +9,9 @@ from .utils import FunctionSpec, OutputType, opt_messages_to_list, backoff_creat
 from funcy import notnone, once, select_values
 import openai
 
+api_base = "https://api.deepseek.com/v1"
+model = "deepseek-reasoner"
+
 logger = logging.getLogger("aide")
 
 _client: openai.OpenAI = None  # type: ignore
@@ -24,7 +27,10 @@ OPENAI_TIMEOUT_EXCEPTIONS = (
 @once
 def _setup_openai_client():
     global _client
-    _client = openai.OpenAI(max_retries=0)
+    _client = openai.OpenAI(
+        base_url=api_base,
+        max_retries=0,
+    )
 
 
 def query(

--- a/aide/utils/config.yaml
+++ b/aide/utils/config.yaml
@@ -43,7 +43,7 @@ agent:
 
   # LLM settings for coding
   code:
-    model: o4-mini
+    model: deepseek-reasoner
     temp: 0.5
 
   # LLM settings for evaluating program output / tracebacks


### PR DESCRIPTION
## Summary
- point OpenAI backend at DeepSeek API
- recognize DeepSeek models as OpenAI provider
- default code model to `deepseek-reasoner`

## Testing
- `python -m py_compile aide/backend/backend_openai.py aide/backend/__init__.py`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_6874f1debe3c832fba277968fc7b19a8