### PR TITLE
Add DeepSeek provider

### DIFF
--- a/aide/backend/__init__.py
+++ b/aide/backend/__init__.py
@@ -1,4 +1,10 @@
-from . import backend_anthropic, backend_openai, backend_openrouter, backend_gemini
+from . import (
+    backend_anthropic,
+    backend_openai,
+    backend_openrouter,
+    backend_gemini,
+    backend_deepseek,
+)
 from .utils import FunctionSpec, OutputType, PromptType, compile_prompt_to_md
 import re
 import logging
@@ -13,6 +19,8 @@ def determine_provider(model: str) -> str:
         return "anthropic"
     elif model.startswith("gemini-"):
         return "gemini"
+    elif model.startswith("deepseek-"):
+        return "deepseek"
     # all other models are handle by openrouter
     else:
         return "openrouter"
@@ -23,6 +31,7 @@ provider_to_query_func = {
     "anthropic": backend_anthropic.query,
     "openrouter": backend_openrouter.query,
     "gemini": backend_gemini.query,
+    "deepseek": backend_deepseek.query,
 }
 
 

--- a/aide/backend/backend_deepseek.py
+++ b/aide/backend/backend_deepseek.py
@@ -1,36 +1,18 @@
-"""Backend for DeepSeek API (OpenAI compatible)."""
+"""Backend for DeepSeek API using the llama-index client."""
 
 import json
 import logging
 import os
-import re
 import time
 
-from .utils import FunctionSpec, OutputType, opt_messages_to_list, backoff_create
-from funcy import notnone, once, select_values
-import openai
+from .utils import FunctionSpec, OutputType, opt_messages_to_list
+from funcy import notnone, select_values
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.llms.deepseek import DeepSeek
 
 logger = logging.getLogger("aide")
 
-_client: openai.OpenAI = None  # type: ignore
-
-OPENAI_TIMEOUT_EXCEPTIONS = (
-    openai.RateLimitError,
-    openai.APIConnectionError,
-    openai.APITimeoutError,
-    openai.InternalServerError,
-)
-
-
-@once
-def _setup_deepseek_client():
-    global _client
-    api_key = os.getenv("DEEPSEEK_API_KEY")
-    _client = openai.OpenAI(
-        api_key=api_key,
-        base_url="https://api.deepseek.com/v1",
-        max_retries=0,
-    )
+DEFAULT_BASE_URL = "https://api.deepseek.com/v1"
 
 
 def query(
@@ -39,114 +21,66 @@ def query(
     func_spec: FunctionSpec | None = None,
     **model_kwargs,
 ) -> tuple[OutputType, float, int, int, dict]:
-    """
-    Query the DeepSeek API, optionally with function calling.
-    If the model doesn't support function calling, gracefully degrade to text generation.
-    """
-    _setup_deepseek_client()
+    """Query the DeepSeek API, optionally with function calling."""
+
     filtered_kwargs: dict = select_values(notnone, model_kwargs)
-    if "max_tokens" in filtered_kwargs:
-        filtered_kwargs["max_output_tokens"] = filtered_kwargs.pop("max_tokens")
+    api_key = os.getenv("DEEPSEEK_API_KEY")
 
-    if (
-        re.match(r"^o\d", filtered_kwargs["model"])
-        or filtered_kwargs["model"] == "codex-mini-latest"
-    ):
-        filtered_kwargs.pop("temperature", None)
+    model_name = filtered_kwargs.pop("model", "deepseek-chat")
+    llm = DeepSeek(model=model_name, api_key=api_key, api_base=DEFAULT_BASE_URL)
 
-    # Convert system/user messages to the format required by the client
-    messages = opt_messages_to_list(system_message, user_message)
-    # Convert to the responses API format
-    for i in range(len(messages)):
-        messages[i]["content"] = [
-            {"type": "input_text", "text": messages[i]["content"]}
-        ]
+    # Convert system/user messages to llama-index ChatMessage objects
+    messages = [
+        ChatMessage.from_str(m["content"], role=m["role"])
+        for m in opt_messages_to_list(system_message, user_message)
+    ]
 
-    # If function calling is requested, attach the function spec
     if func_spec is not None:
-        filtered_kwargs["tools"] = [func_spec.as_openai_responses_tool_dict]
-        filtered_kwargs["tool_choice"] = func_spec.openai_responses_tool_choice_dict
+        filtered_kwargs["tools"] = [func_spec.as_openai_tool_dict]
+        filtered_kwargs["tool_choice"] = func_spec.openai_tool_choice_dict
 
     t0 = time.time()
-
-    # Attempt the API call
-    try:
-        response = backoff_create(
-            _client.responses.create,
-            OPENAI_TIMEOUT_EXCEPTIONS,
-            input=messages,
-            **filtered_kwargs,
-        )
-    except openai.BadRequestError as e:
-        # Check whether the error indicates that function calling is not supported
-        if "function calling" in str(e).lower() or "tools" in str(e).lower():
-            logger.warning(
-                "Function calling was attempted but is not supported by this model. "
-                "Falling back to plain text generation."
-            )
-            # Remove function-calling parameters and retry
-            filtered_kwargs.pop("tools", None)
-            filtered_kwargs.pop("tool_choice", None)
-
-            # Retry without function calling
-            response = backoff_create(
-                _client.responses.create,
-                OPENAI_TIMEOUT_EXCEPTIONS,
-                input=messages,
-                **filtered_kwargs,
-            )
-        else:
-            # If it's some other error, re-raise
-            raise
-
+    response = llm.chat(messages, **filtered_kwargs)
     req_time = time.time() - t0
 
-    # Parse the output from responses API
-    if (
-        hasattr(response, "output")
-        and response.output is not None
-        and len(response.output) > 0
-    ):
-        # Look for function calls in the response output items
-        function_call_item = None
-        for output_item in response.output:
-            if hasattr(output_item, "type") and output_item.type == "function_call":
-                function_call_item = output_item
-                break
+    message = response.message
+    output: OutputType = message.content
 
-        if function_call_item is not None:
-            # Function call found
-            if func_spec is not None and function_call_item.name == func_spec.name:
+    # Handle function call outputs if present
+    if func_spec is not None:
+        fc_info = message.additional_kwargs.get("tool_calls") or message.additional_kwargs.get(
+            "function_call"
+        )
+        if fc_info:
+            if isinstance(fc_info, list):
+                fc = fc_info[0].get("function", {})
+            else:
+                fc = fc_info
+
+            if fc.get("name") == func_spec.name:
                 try:
-                    output = json.loads(function_call_item.arguments)
+                    output = json.loads(fc.get("arguments", "{}"))
                 except json.JSONDecodeError as ex:
                     logger.error(
-                        "Error decoding function arguments:\n"
-                        f"{function_call_item.arguments}"
+                        "Error decoding function arguments:\n" f"{fc.get('arguments')}"
                     )
                     raise ex
             else:
-                # Function name mismatch or no func_spec
-                if func_spec is not None:
-                    logger.warning(
-                        f"Function name mismatch: expected {func_spec.name}, "
-                        f"got {function_call_item.name}. Fallback to text."
-                    )
-                output = response.output_text
-        else:
-            # No function call, use regular text output
-            output = response.output_text
-    else:
-        # Fallback to output_text
-        output = response.output_text
+                logger.warning(
+                    f"Function name mismatch: expected {func_spec.name}, got {fc.get('name')}. Fallback to text."
+                )
 
-    in_tokens = response.usage.input_tokens
-    out_tokens = response.usage.output_tokens
+    usage = getattr(response.raw, "usage", None)
+    if usage is None:
+        in_tokens = out_tokens = 0
+    else:
+        in_tokens = getattr(usage, "prompt_tokens", usage.get("prompt_tokens", 0))
+        out_tokens = getattr(usage, "completion_tokens", usage.get("completion_tokens", 0))
 
     info = {
-        "system_fingerprint": getattr(response, "system_fingerprint", None),
-        "model": response.model,
-        "created": getattr(response, "created", None),
+        "system_fingerprint": getattr(response.raw, "system_fingerprint", None),
+        "model": model_name,
+        "created": getattr(response.raw, "created", None),
     }
 
     return output, req_time, in_tokens, out_tokens, info

--- a/aide/backend/backend_deepseek.py
+++ b/aide/backend/backend_deepseek.py
@@ -1,0 +1,152 @@
+"""Backend for DeepSeek API (OpenAI compatible)."""
+
+import json
+import logging
+import os
+import re
+import time
+
+from .utils import FunctionSpec, OutputType, opt_messages_to_list, backoff_create
+from funcy import notnone, once, select_values
+import openai
+
+logger = logging.getLogger("aide")
+
+_client: openai.OpenAI = None  # type: ignore
+
+OPENAI_TIMEOUT_EXCEPTIONS = (
+    openai.RateLimitError,
+    openai.APIConnectionError,
+    openai.APITimeoutError,
+    openai.InternalServerError,
+)
+
+
+@once
+def _setup_deepseek_client():
+    global _client
+    api_key = os.getenv("DEEPSEEK_API_KEY")
+    _client = openai.OpenAI(
+        api_key=api_key,
+        base_url="https://api.deepseek.com/v1",
+        max_retries=0,
+    )
+
+
+def query(
+    system_message: str | None,
+    user_message: str | None,
+    func_spec: FunctionSpec | None = None,
+    **model_kwargs,
+) -> tuple[OutputType, float, int, int, dict]:
+    """
+    Query the DeepSeek API, optionally with function calling.
+    If the model doesn't support function calling, gracefully degrade to text generation.
+    """
+    _setup_deepseek_client()
+    filtered_kwargs: dict = select_values(notnone, model_kwargs)
+    if "max_tokens" in filtered_kwargs:
+        filtered_kwargs["max_output_tokens"] = filtered_kwargs.pop("max_tokens")
+
+    if (
+        re.match(r"^o\d", filtered_kwargs["model"])
+        or filtered_kwargs["model"] == "codex-mini-latest"
+    ):
+        filtered_kwargs.pop("temperature", None)
+
+    # Convert system/user messages to the format required by the client
+    messages = opt_messages_to_list(system_message, user_message)
+    # Convert to the responses API format
+    for i in range(len(messages)):
+        messages[i]["content"] = [
+            {"type": "input_text", "text": messages[i]["content"]}
+        ]
+
+    # If function calling is requested, attach the function spec
+    if func_spec is not None:
+        filtered_kwargs["tools"] = [func_spec.as_openai_responses_tool_dict]
+        filtered_kwargs["tool_choice"] = func_spec.openai_responses_tool_choice_dict
+
+    t0 = time.time()
+
+    # Attempt the API call
+    try:
+        response = backoff_create(
+            _client.responses.create,
+            OPENAI_TIMEOUT_EXCEPTIONS,
+            input=messages,
+            **filtered_kwargs,
+        )
+    except openai.BadRequestError as e:
+        # Check whether the error indicates that function calling is not supported
+        if "function calling" in str(e).lower() or "tools" in str(e).lower():
+            logger.warning(
+                "Function calling was attempted but is not supported by this model. "
+                "Falling back to plain text generation."
+            )
+            # Remove function-calling parameters and retry
+            filtered_kwargs.pop("tools", None)
+            filtered_kwargs.pop("tool_choice", None)
+
+            # Retry without function calling
+            response = backoff_create(
+                _client.responses.create,
+                OPENAI_TIMEOUT_EXCEPTIONS,
+                input=messages,
+                **filtered_kwargs,
+            )
+        else:
+            # If it's some other error, re-raise
+            raise
+
+    req_time = time.time() - t0
+
+    # Parse the output from responses API
+    if (
+        hasattr(response, "output")
+        and response.output is not None
+        and len(response.output) > 0
+    ):
+        # Look for function calls in the response output items
+        function_call_item = None
+        for output_item in response.output:
+            if hasattr(output_item, "type") and output_item.type == "function_call":
+                function_call_item = output_item
+                break
+
+        if function_call_item is not None:
+            # Function call found
+            if func_spec is not None and function_call_item.name == func_spec.name:
+                try:
+                    output = json.loads(function_call_item.arguments)
+                except json.JSONDecodeError as ex:
+                    logger.error(
+                        "Error decoding function arguments:\n"
+                        f"{function_call_item.arguments}"
+                    )
+                    raise ex
+            else:
+                # Function name mismatch or no func_spec
+                if func_spec is not None:
+                    logger.warning(
+                        f"Function name mismatch: expected {func_spec.name}, "
+                        f"got {function_call_item.name}. Fallback to text."
+                    )
+                output = response.output_text
+        else:
+            # No function call, use regular text output
+            output = response.output_text
+    else:
+        # Fallback to output_text
+        output = response.output_text
+
+    in_tokens = response.usage.input_tokens
+    out_tokens = response.usage.output_tokens
+
+    info = {
+        "system_fingerprint": getattr(response, "system_fingerprint", None),
+        "model": response.model,
+        "created": getattr(response, "created", None),
+    }
+
+    return output, req_time, in_tokens, out_tokens, info

--- a/aide/backend/backend_deepseek.py
+++ b/aide/backend/backend_deepseek.py
@@ -48,34 +48,57 @@ def query(
 
     # Handle function call outputs if present
     if func_spec is not None:
-        fc_info = message.additional_kwargs.get("tool_calls") or message.additional_kwargs.get(
-            "function_call"
-        )
+        fc_info = message.additional_kwargs.get(
+            "tool_calls",
+        ) or message.additional_kwargs.get("function_call")
         if fc_info:
             if isinstance(fc_info, list):
-                fc = fc_info[0].get("function", {})
+                fc_raw = fc_info[0]
             else:
-                fc = fc_info
+                fc_raw = fc_info
 
-            if fc.get("name") == func_spec.name:
+            if hasattr(fc_raw, "function"):
+                fc = {
+                    "name": getattr(fc_raw.function, "name", None),
+                    "arguments": getattr(fc_raw.function, "arguments", "{}"),
+                }
+            elif isinstance(fc_raw, dict) and "function" in fc_raw:
+                fc = fc_raw.get("function", {})
+            else:
+                fc = fc_raw
+
+            if isinstance(fc, dict) and fc.get("name") == func_spec.name:
                 try:
                     output = json.loads(fc.get("arguments", "{}"))
                 except json.JSONDecodeError as ex:
                     logger.error(
-                        "Error decoding function arguments:\n" f"{fc.get('arguments')}"
+                        "Error decoding function arguments:\n%s",
+                        fc.get("arguments"),
                     )
                     raise ex
             else:
                 logger.warning(
-                    f"Function name mismatch: expected {func_spec.name}, got {fc.get('name')}. Fallback to text."
+                    "Function name mismatch: expected %s, got %s. Fallback to text.",
+                    func_spec.name,
+                    (
+                        fc.get("name")
+                        if isinstance(fc, dict)
+                        else getattr(fc, "name", None)
+                    ),
                 )
 
     usage = getattr(response.raw, "usage", None)
     if usage is None:
         in_tokens = out_tokens = 0
     else:
-        in_tokens = getattr(usage, "prompt_tokens", usage.get("prompt_tokens", 0))
-        out_tokens = getattr(usage, "completion_tokens", usage.get("completion_tokens", 0))
+        in_tokens = getattr(usage, "prompt_tokens", None)
+        if in_tokens is None and hasattr(usage, "get"):
+            in_tokens = usage.get("prompt_tokens", 0)
+        out_tokens = getattr(usage, "completion_tokens", None)
+        if out_tokens is None and hasattr(usage, "get"):
+            out_tokens = usage.get("completion_tokens", 0)
+        in_tokens = in_tokens or 0
+        out_tokens = out_tokens or 0
 
     info = {
         "system_fingerprint": getattr(response.raw, "system_fingerprint", None),

--- a/aide/run.py
+++ b/aide/run.py
@@ -24,6 +24,7 @@ from rich.progress import (
 from rich.text import Text
 from rich.status import Status
 from rich.tree import Tree
+import os
 from .utils.config import load_task_desc, prep_agent_workspace, save_run, load_cfg
 
 logger = logging.getLogger("aide")
@@ -54,6 +55,9 @@ def journal_to_rich_tree(journal: Journal):
 
 
 def run():
+    if not os.getenv("DEEPSEEK_API_KEY"):
+        logger.error("DEEPSEEK_API_KEY environment variable not set. Aborting run.")
+        raise SystemExit(1)
     cfg = load_cfg()
     logger.info(f'Starting run "{cfg.exp_name}"')
 

--- a/aide/utils/config.yaml
+++ b/aide/utils/config.yaml
@@ -43,12 +43,12 @@ agent:
 
   # LLM settings for coding
   code:
-    model: o4-mini
+    model: deepseek-coder
     temp: 0.5
 
   # LLM settings for evaluating program output / tracebacks
   feedback:
-    model: gpt-4.1-mini
+    model: deepseek-reasoner
     temp: 0.5
 
   # hyperparameters for the tree search

--- a/aide/webui/app.py
+++ b/aide/webui/app.py
@@ -53,6 +53,7 @@ class WebUI:
             "anthropic_key": os.getenv("ANTHROPIC_API_KEY", ""),
             "gemini_key": os.getenv("GEMINI_API_KEY", ""),
             "openrouter_key": os.getenv("OPENROUTER_API_KEY", ""),
+            "deepseek_key": os.getenv("DEEPSEEK_API_KEY", ""),
         }
 
     @staticmethod
@@ -139,10 +140,21 @@ class WebUI:
                 type="password",
                 label_visibility="collapsed",
             )
+            st.markdown(
+                "<p style='text-align: center;'>DeepSeek API Key</p>",
+                unsafe_allow_html=True,
+            )
+            deepseek_key = st.text_input(
+                "DeepSeek API Key",
+                value=self.env_vars.get("deepseek_key", ""),
+                type="password",
+                label_visibility="collapsed",
+            )
             if st.button("Save API Keys", use_container_width=True):
                 st.session_state.openai_key = openai_key
                 st.session_state.anthropic_key = anthropic_key
                 st.session_state.openrouter_key = openrouter_key
+                st.session_state.deepseek_key = deepseek_key
                 st.success("API keys saved!")
 
     def render_input_section(self, results_col):
@@ -357,6 +369,8 @@ class WebUI:
             os.environ["GEMINI_API_KEY"] = st.session_state.gemini_key
         if st.session_state.get("openrouter_key"):
             os.environ["OPENROUTER_API_KEY"] = st.session_state.openrouter_key
+        if st.session_state.get("deepseek_key"):
+            os.environ["DEEPSEEK_API_KEY"] = st.session_state.deepseek_key
 
     def prepare_input_directory(self, files):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,3 +92,6 @@ xlrd
 backoff
 streamlit==1.40.2
 python-dotenv
+
+llama-index-llms-deepseek>=0.1.2
+llama-index-llms-openai-like>=0.4.0


### PR DESCRIPTION
## Summary
- add DeepSeek backend using OpenAI-compatible API
- wire up DeepSeek provider selection in backend dispatcher
- default to DeepSeek models in config
- enable DeepSeek API keys in the web UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ff036b6c832fb937ed290f18185f