### PR TITLE
Fix DeepSeek tool call parsing

### DIFF
--- a/aide/backend/backend_deepseek.py
+++ b/aide/backend/backend_deepseek.py
@@ -48,34 +48,57 @@ def query(
 
     # Handle function call outputs if present
     if func_spec is not None:
-        fc_info = message.additional_kwargs.get("tool_calls") or message.additional_kwargs.get(
-            "function_call"
-        )
+        fc_info = message.additional_kwargs.get(
+            "tool_calls",
+        ) or message.additional_kwargs.get("function_call")
         if fc_info:
             if isinstance(fc_info, list):
-                fc = fc_info[0].get("function", {})
+                fc_raw = fc_info[0]
             else:
-                fc = fc_info
+                fc_raw = fc_info
 
-            if fc.get("name") == func_spec.name:
+            if hasattr(fc_raw, "function"):
+                fc = {
+                    "name": getattr(fc_raw.function, "name", None),
+                    "arguments": getattr(fc_raw.function, "arguments", "{}"),
+                }
+            elif isinstance(fc_raw, dict) and "function" in fc_raw:
+                fc = fc_raw.get("function", {})
+            else:
+                fc = fc_raw
+
+            if isinstance(fc, dict) and fc.get("name") == func_spec.name:
                 try:
                     output = json.loads(fc.get("arguments", "{}"))
                 except json.JSONDecodeError as ex:
                     logger.error(
-                        "Error decoding function arguments:\n" f"{fc.get('arguments')}"
+                        "Error decoding function arguments:\n%s",
+                        fc.get("arguments"),
                     )
                     raise ex
             else:
                 logger.warning(
-                    f"Function name mismatch: expected {func_spec.name}, got {fc.get('name')}. Fallback to text."
+                    "Function name mismatch: expected %s, got %s. Fallback to text.",
+                    func_spec.name,
+                    (
+                        fc.get("name")
+                        if isinstance(fc, dict)
+                        else getattr(fc, "name", None)
+                    ),
                 )
 
     usage = getattr(response.raw, "usage", None)
     if usage is None:
         in_tokens = out_tokens = 0
     else:
-        in_tokens = getattr(usage, "prompt_tokens", usage.get("prompt_tokens", 0))
-        out_tokens = getattr(usage, "completion_tokens", usage.get("completion_tokens", 0))
+        in_tokens = getattr(usage, "prompt_tokens", None)
+        if in_tokens is None and hasattr(usage, "get"):
+            in_tokens = usage.get("prompt_tokens", 0)
+        out_tokens = getattr(usage, "completion_tokens", None)
+        if out_tokens is None and hasattr(usage, "get"):
+            out_tokens = usage.get("completion_tokens", 0)
+        in_tokens = in_tokens or 0
+        out_tokens = out_tokens or 0
 
     info = {
         "system_fingerprint": getattr(response.raw, "system_fingerprint", None),

--- a/aide/run.py
+++ b/aide/run.py
@@ -24,6 +24,7 @@ from rich.progress import (
 from rich.text import Text
 from rich.status import Status
 from rich.tree import Tree
+import os
 from .utils.config import load_task_desc, prep_agent_workspace, save_run, load_cfg
 
 logger = logging.getLogger("aide")
@@ -54,6 +55,9 @@ def journal_to_rich_tree(journal: Journal):
 
 
 def run():
+    if not os.getenv("DEEPSEEK_API_KEY"):
+        logger.error("DEEPSEEK_API_KEY environment variable not set. Aborting run.")
+        raise SystemExit(1)
     cfg = load_cfg()
     logger.info(f'Starting run "{cfg.exp_name}"')
 


### PR DESCRIPTION
## Summary
- improve DeepSeek backend handling of OpenAI tool call objects
- ensure token usage is parsed safely
- runtime check for missing DEEPSEEK_API_KEY remains

## Testing
- `black aide/backend/backend_deepseek.py aide/run.py`
- `pytest`
- ❌ `aide data_dir="aide/example_tasks/house_prices" goal="Predict the sales price for each house" eval="RMSE between log-prices" agent.steps=2 agent.feedback.model=deepseek-chat` *(fails: network access to api.deepseek.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6875424ae6f0832f9dfcff7bb1cae049